### PR TITLE
Move version to header and fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
           CHART_FILE="helm/Chart.yaml"
 
           echo "Updating $CONFIG_FILE with APP_VERSION=$APP_VERSION"
-          sed -i "s/^    APP_VERSION: str = \".*\"/    APP_VERSION: str = \"$APP_VERSION\"/" $CONFIG_FILE
+          sed -i "s/^    APP_VERSION = '.*'/    APP_VERSION = '$APP_VERSION'/" $CONFIG_FILE
           
           echo "Updating $CHART_FILE with appVersion=$APP_VERSION"
           sed -i "s/^appVersion:.*/appVersion: \"$APP_VERSION\"/" $CHART_FILE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## [1.2.2]
+
+### Changed
+- App version moved from the footer to the header, displayed next to the KubePing logo
+
+### Fixed
+- Release workflow now correctly bumps `APP_VERSION` in `config.py` (sed pattern updated to match the actual file format)
+
 ## [1.2.1]
 
 ### Changed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
-# KubePing 1.2.1
+# KubePing 1.2.2
 
-KubePing 1.2.1 makes the HTTP probe sensitive to SSL/TLS certificate errors.
+KubePing 1.2.2 relocates the app version display and fixes the release workflow version bumping.
 
-The HTTP probe previously skipped TLS certificate verification (`InsecureSkipVerify`), so certificate problems were never reported. Verification is now enabled, and all SSL/TLS errors — expired certificates, hostname mismatches, untrusted or unknown certificate authorities, and handshake failures — are surfaced with their original Go TLS error messages.
+The app version is now shown in the header next to the KubePing logo instead of the footer.

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -105,6 +105,15 @@ body {
   color: var(--text-dim);
 }
 
+.app-version {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--text-dim);
+  opacity: 0.6;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
 .ip-value {
   font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
   font-size: 0.85rem;

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -17,6 +17,7 @@
             </div>
             <div class="topbar-center">
                 <span class="logo"><span class="logo-kube">Kube</span><span class="logo-ping">Ping</span></span>
+                <span class="app-version">{{ version }}</span>
             </div>
             <div class="topbar-right">
                 <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle theme">
@@ -97,7 +98,6 @@
 
     <footer class="footer">
         <div class="footer-inner">
-            <span>{{ version }}</span>
             <a href="https://github.com/teymurgahramanov/kubeping" target="_blank">GitHub</a>
         </div>
     </footer>


### PR DESCRIPTION
Move version display from footer to topbar next to the logo. Update release workflow sed pattern to correctly match config.py format.